### PR TITLE
Add model validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/chai-as-promised": "0.0.31",
     "@types/mocha": "^2.2.41",
     "@types/sinon": "^2.3.3",
+    "@types/sinon-chai": "^2.7.29",
     "chai": "^4.0.2",
     "chai-as-promised": "^7.0.0",
     "codecov": "^2.2.0",
@@ -22,6 +23,7 @@
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
     "sinon": "^2.4.0",
+    "sinon-chai": "^2.13.0",
     "ts-node": "^3.1.0",
     "tslint": "^5.4.3",
     "typescript": "^2.3.4"

--- a/packages/octonom/lib/errors.ts
+++ b/packages/octonom/lib/errors.ts
@@ -1,0 +1,22 @@
+import { Model } from './model';
+
+export class ExtendableError extends Error {
+  constructor(message: string, prototype: object) {
+    super(message);
+
+    // see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md
+    Object.setPrototypeOf(this, prototype);
+  }
+}
+
+export class ValidationError extends ExtendableError {
+  constructor(
+    message: string,
+    public readonly reason: string,
+    public readonly value: any,
+    public readonly path: Array<string | number>,
+    public readonly instance: Model<object>,
+  ) {
+    super(message, ValidationError.prototype);
+  }
+}

--- a/packages/octonom/lib/errors.ts
+++ b/packages/octonom/lib/errors.ts
@@ -12,10 +12,10 @@ export class ExtendableError extends Error {
 export class ValidationError extends ExtendableError {
   constructor(
     message: string,
-    public readonly reason: string,
-    public readonly value: any,
-    public readonly path: Array<string | number>,
-    public readonly instance: Model<object>,
+    public reason?: string,
+    public value?: any,
+    public path?: Array<string | number>,
+    public instance?: Model<object>,
   ) {
     super(message, ValidationError.prototype);
   }

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -194,7 +194,6 @@ describe('Model', () => {
         const toObject = spy(person, 'toObject');
         const group = new GroupWithArrayModel({id: '1337', members: [person]});
         expect(group.toObject({unpopulate: true})).to.eql({id: '1337', members: [{id: '42', name: 'Bob'}]});
-        expect(toObject.calledWith({unpopulate: true}));
       });
     });
   });

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -1,5 +1,3 @@
-import { spy } from 'sinon';
-
 import { collections } from '../test/data/collections';
 import { CatModel } from '../test/data/models/cat';
 import { DiscussionModel } from '../test/data/models/discussion';
@@ -191,7 +189,6 @@ describe('Model', () => {
     describe('toObject()', () => {
       it('should run toObject on array elements', async () => {
         const person = new PersonModel({id: '42', name: 'Bob'});
-        const toObject = spy(person, 'toObject');
         const group = new GroupWithArrayModel({id: '1337', members: [person]});
         expect(group.toObject({unpopulate: true})).to.eql({id: '1337', members: [{id: '42', name: 'Bob'}]});
       });

--- a/packages/octonom/lib/schema.ts
+++ b/packages/octonom/lib/schema.ts
@@ -1,5 +1,6 @@
 import { difference, forEach, isArray, isBoolean, isDate, isFunction, isNumber, isString } from 'lodash';
 
+import { Model } from './model';
 import { ModelArray } from './model-array';
 
 export interface ISchemaValueBase {
@@ -10,6 +11,7 @@ export interface ISchemaValueBase {
 export interface ISchemaValueAny extends ISchemaValueBase {
   type: 'any';
   default?: () => any;
+  validate?(value: any, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueArray extends ISchemaValueBase {
@@ -17,11 +19,13 @@ export interface ISchemaValueArray extends ISchemaValueBase {
   definition: SchemaValue;
   minLength?: number;
   maxLength?: number;
+  validate?(value: any[], path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueBoolean extends ISchemaValueBase {
   type: 'boolean';
   default?: boolean | (() => boolean);
+  validate?(value: boolean, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueDate extends ISchemaValueBase {
@@ -29,6 +33,7 @@ export interface ISchemaValueDate extends ISchemaValueBase {
   default?: Date | (() => Date);
   min?: Date;
   max?: Date;
+  validate?(value: Date, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface IModelConstructor {
@@ -39,6 +44,7 @@ export interface IModelConstructor {
 export interface ISchemaValueModel extends ISchemaValueBase {
   type: 'model';
   model: IModelConstructor;
+  validate?(value: Model<object>, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueNumber extends ISchemaValueBase {
@@ -47,16 +53,19 @@ export interface ISchemaValueNumber extends ISchemaValueBase {
   min?: number;
   max?: number;
   integer?: boolean;
+  validate?(value: number, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueObject extends ISchemaValueBase {
   type: 'object';
   definition: ISchemaMap;
+  validate?(value: object, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueReference extends ISchemaValueBase {
   type: 'reference';
   collection: () => any; // TODO
+  validate?(value: any, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export interface ISchemaValueString extends ISchemaValueBase {
@@ -67,6 +76,7 @@ export interface ISchemaValueString extends ISchemaValueBase {
   min?: number;
   max?: number;
   regex?: RegExp;
+  validate?(value: string, path: Array<string | number>, instance: Model<any>): Promise<void>;
 }
 
 export type SchemaValue = ISchemaValueAny | ISchemaValueArray | ISchemaValueBoolean |

--- a/packages/octonom/lib/schema.ts
+++ b/packages/octonom/lib/schema.ts
@@ -71,7 +71,6 @@ export interface ISchemaValueReference extends ISchemaValueBase {
 export interface ISchemaValueString extends ISchemaValueBase {
   type: 'string';
   default?: string | (() => string);
-  allowEmpty?: boolean;
   enum?: string[];
   min?: number;
   max?: number;

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -1,9 +1,9 @@
 import { ValidationError } from './errors';
 import { Model } from './model';
 import { SchemaValue } from './schema';
-import { validate } from './validate';
+import { validateValue } from './validate';
 
-describe('validate()', () => {
+describe('validateValue()', () => {
   function getInstance(schema: SchemaValue, data: object) {
     class TestModel extends Model<TestModel> {
       @Model.PropertySchema(schema)
@@ -15,14 +15,14 @@ describe('validate()', () => {
   it('should throw a validation error if required value is undefined', async () => {
     const schema: SchemaValue = {type: 'any', required: true};
     const instance = getInstance(schema, {});
-    await expect(validate(schema, undefined, ['key'], instance))
+    await expect(validateValue(schema, undefined, ['key'], instance))
       .to.be.rejectedWith(ValidationError, 'Required value is undefined.');
   });
 
   it('should pass if value is undefined and not required', async () => {
     const schema: SchemaValue = {type: 'any'};
     const instance = getInstance(schema, {});
-    await validate(schema, undefined, ['key'], instance);
+    await validateValue(schema, undefined, ['key'], instance);
   });
 
   describe('type any', () => {
@@ -38,14 +38,14 @@ describe('validate()', () => {
     it('should throw a ValidationError if custom validator throws', async () => {
       const value = {foo: 'invalid'};
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Custom error.');
     });
 
     it('should pass if validator passes', async () => {
       const value = {foo: 'bar'};
       const instance = getInstance(schema, {key: value});
-      await validate(schema, value, ['key'], instance);
+      await validateValue(schema, value, ['key'], instance);
     });
   });
 
@@ -72,42 +72,42 @@ describe('validate()', () => {
     it('should throw a ValidationError if not an array', async () => {
       const value = 'foo';
       const instance = getInstance(schema, {key: ['foo']}); // pretend it's an array
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Value is not an array.');
     });
 
     it('should throw a ValidationError with too few elements', async () => {
       const value = [];
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Array must have at least 1 elements.');
     });
 
     it('should throw a ValidationError with too many', async () => {
       const value = [1, 2, 3];
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Array must have at most 2 elements.');
     });
 
     it('should throw a ValidationError if custom validator throws', async () => {
       const value = [1, 'baz'];
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Array must not contain baz.');
     });
 
     it('should throw a ValidationError if nested validator throws', async () => {
       const value = ['foo', 'invalid'];
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Custom error.');
     });
 
     it('should pass if validator passes', async () => {
       const value = ['foo', 'bar'];
       const instance = getInstance(schema, {key: value});
-      await validate(schema, value, ['key'], instance);
+      await validateValue(schema, value, ['key'], instance);
     });
   });
 
@@ -124,21 +124,21 @@ describe('validate()', () => {
     it('should throw a ValidationError if value not a boolean', async () => {
       const value = 'foo';
       const instance = getInstance(schema, {key: true}); // pretend it's a boolean
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Value is not a boolean.');
     });
 
     it('should throw a ValidationError if custom validator throws', async () => {
       const value = false;
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'False not allowed.');
     });
 
     it('should pass if validator passes', async () => {
       const value = true;
       const instance = getInstance(schema, {key: value});
-      await validate(schema, value, ['key'], instance);
+      await validateValue(schema, value, ['key'], instance);
     });
   });
 
@@ -157,35 +157,86 @@ describe('validate()', () => {
     it('should throw a ValidationError if not a date', async () => {
       const value = 'foo';
       const instance = getInstance(schema, {key: new Date()}); // pretend it's a date
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Value is not a date.');
     });
 
     it('should throw a ValidationError if before min date', async () => {
       const value = new Date('1999-12-31');
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, `Date must not be before ${schema.min}`);
     });
 
     it('should throw a ValidationError if after max date', async () => {
       const value = new Date('2019-12-31');
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, `Date must not be after ${schema.max}`);
     });
 
     it('should throw a ValidationError if custom validator throws', async () => {
       const value = new Date('2017-09-03');
       const instance = getInstance(schema, {key: value});
-      await expect(validate(schema, value, ['key'], instance))
+      await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, '2017-09-03 is not allowed.');
     });
 
     it('should pass if validator passes', async () => {
       const value = new Date('2016-06-06');
       const instance = getInstance(schema, {key: value});
-      await validate(schema, value, ['key'], instance);
+      await validateValue(schema, value, ['key'], instance);
+    });
+  });
+
+  describe('type model', () => {
+    class NestedModel extends Model<NestedModel> {
+      @Model.PropertySchema({
+        type: 'any',
+        validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+          if (value === 'baz') {
+            throw new ValidationError('Value baz is not allowed.', 'custom', value, path, instance);
+          }
+        },
+      })
+      public foo: any;
+    }
+
+    const schema: SchemaValue = {
+      type: 'model',
+      model: NestedModel,
+      validate: async (value: NestedModel, path: Array<string | number>, instance: Model<any>) => {
+        if (value.foo === 'invalid') {
+          throw new ValidationError('Value invalid is not allowed.', 'custom', value, path, instance);
+        }
+      },
+    };
+
+    it('should throw a ValidationError if not a model instance', async () => {
+      const value = {foo: 'bar'};
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Value is not an instance of NestedModel.');
+    });
+
+    it('should throw a ValidationError if nested model\'s validator throws', async () => {
+      const value = new NestedModel({foo: 'baz'});
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Value baz is not allowed.');
+    });
+
+    it('should throw a ValidationError if custom validator throws', async () => {
+      const value = new NestedModel({foo: 'invalid'});
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Value invalid is not allowed.');
+    });
+
+    it('should pass if validator passes', async () => {
+      const value = new NestedModel({foo: 'bar'});
+      const instance = getInstance(schema, {key: value});
+      await validateValue(schema, value, ['key'], instance);
     });
   });
 });

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -60,9 +60,11 @@ describe('validate()', () => {
           }
         },
       },
+      minLength: 1,
+      maxLength: 2,
       validate: async (value: any[], path: Array<string | number>, instance: Model<any>) => {
-        if (value.length > 2) {
-          throw new ValidationError('Array is too long.', 'custom', value, path, instance);
+        if (value.indexOf('baz') !== -1) {
+          throw new ValidationError('Array must not contain baz.', 'custom', value, path, instance);
         }
       },
     };
@@ -74,11 +76,25 @@ describe('validate()', () => {
         .to.be.rejectedWith(ValidationError, 'Value is not an array.');
     });
 
-    it('should throw a ValidationError if custom validator throws', async () => {
+    it('should throw a ValidationError with too few elements', async () => {
+      const value = [];
+      const instance = getInstance(schema, {key: value});
+      await expect(validate(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Array must have at least 1 elements.');
+    });
+
+    it('should throw a ValidationError with too many', async () => {
       const value = [1, 2, 3];
       const instance = getInstance(schema, {key: value});
       await expect(validate(schema, value, ['key'], instance))
-        .to.be.rejectedWith(ValidationError, 'Array is too long.');
+        .to.be.rejectedWith(ValidationError, 'Array must have at most 2 elements.');
+    });
+
+    it('should throw a ValidationError if custom validator throws', async () => {
+      const value = [1, 'baz'];
+      const instance = getInstance(schema, {key: value});
+      await expect(validate(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Array must not contain baz.');
     });
 
     it('should throw a ValidationError if nested validator throws', async () => {

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -239,4 +239,59 @@ describe('validateValue()', () => {
       await validateValue(schema, value, ['key'], instance);
     });
   });
+
+  describe('type number', () => {
+    const schema: SchemaValue = {
+      type: 'number',
+      min: 1,
+      max: 5,
+      integer: true,
+      validate: async (value: number, path: Array<string | number>, instance: Model<any>) => {
+        if (value === 3) {
+          throw new ValidationError('3 is not allowed.', 'custom', value, path, instance);
+        }
+      },
+    };
+
+    it('should throw a ValidationError if not a number', async () => {
+      const value = 'foo';
+      const instance = getInstance(schema, {key: 1}); // pretend it's a date
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Value is not a number.');
+    });
+
+    it('should throw a ValidationError if not an integer', async () => {
+      const value = 2.5;
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Number is not an integer.');
+    });
+
+    it('should throw a ValidationError if less than min', async () => {
+      const value = 0;
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, `Number must not be less than ${schema.min}`);
+    });
+
+    it('should throw a ValidationError if greater than max', async () => {
+      const value = 6;
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, `Number must not be greater than ${schema.max}`);
+    });
+
+    it('should throw a ValidationError if custom validator throws', async () => {
+      const value = 3;
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, '3 is not allowed.');
+    });
+
+    it('should pass if validator passes', async () => {
+      const value = 2;
+      const instance = getInstance(schema, {key: value});
+      await validateValue(schema, value, ['key'], instance);
+    });
+  });
 });

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -1,5 +1,3 @@
-import { stub } from 'sinon';
-
 import { ValidationError } from './errors';
 import { Model } from './model';
 import { SchemaValue } from './schema';

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -110,4 +110,35 @@ describe('validate()', () => {
       await validate(schema, value, ['key'], instance);
     });
   });
+
+  describe('type boolean', () => {
+    const schema: SchemaValue = {
+      type: 'boolean',
+      validate: async (value: boolean, path: Array<string | number>, instance: Model<any>) => {
+        if (value === false) {
+          throw new ValidationError('False not allowed.', 'custom', value, path, instance);
+        }
+      },
+    };
+
+    it('should throw a ValidationError if value not a boolean', async () => {
+      const value = 'foo';
+      const instance = getInstance(schema, {key: true}); // pretend it's a boolean
+      await expect(validate(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'Value is not a boolean.');
+    });
+
+    it('should throw a ValidationError if custom validator throws', async () => {
+      const value = false;
+      const instance = getInstance(schema, {key: value});
+      await expect(validate(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'False not allowed.');
+    });
+
+    it('should pass if validator passes', async () => {
+      const value = true;
+      const instance = getInstance(schema, {key: value});
+      await validate(schema, value, ['key'], instance);
+    });
+  });
 });

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -46,6 +46,13 @@ describe('validateValue()', () => {
       .to.be.rejectedWith(ValidationError, 'Required value is undefined.');
   });
 
+  it('should throw an Error if type is unknown', async () => {
+    const schema: SchemaValue = {type: 'invalid'} as any;
+    const instance = getInstance({type: 'string'}, {key: 'test'}); // fake for instance
+    await expect(validateValue(schema, 'test', ['key'], instance))
+      .to.be.rejectedWith(Error, 'Type invalid is unknown.');
+  });
+
   it('should pass if value is undefined and not required', async () => {
     const schema: SchemaValue = {type: 'any'};
     const instance = getInstance(schema, {});

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -1,0 +1,53 @@
+import { stub } from 'sinon';
+
+import { ValidationError } from './errors';
+import { Model } from './model';
+import { SchemaValue } from './schema';
+import { validate } from './validate';
+
+describe('validate()', () => {
+  function getInstance(schema: SchemaValue, data: object) {
+    class TestModel extends Model<TestModel> {
+      @Model.PropertySchema(schema)
+      public key: any;
+    }
+    return new TestModel(data);
+  }
+
+  it('should throw a validation error if required value is undefined', async () => {
+    const schema: SchemaValue = {type: 'any', required: true};
+    const instance = getInstance(schema, {});
+    await expect(validate(schema, undefined, ['key'], instance))
+      .to.be.rejectedWith(ValidationError, 'Required value is undefined.');
+  });
+
+  it('should pass if value is undefined and not required', async () => {
+    const schema: SchemaValue = {type: 'any'};
+    const instance = getInstance(schema, {});
+    await validate(schema, undefined, ['key'], instance);
+  });
+
+  describe('type any', () => {
+    const schema: SchemaValue = {
+      type: 'any',
+      validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+        if (value.foo === 'invalid') {
+          throw new ValidationError('custom error', 'custom', value, path, instance);
+        }
+      },
+    };
+
+    it('should throw a ValidationError if custom validator throws', async () => {
+      const value = {foo: 'invalid'};
+      const instance = getInstance(schema, {key: value});
+      await expect(validate(schema, value, ['key'], instance))
+        .to.be.rejectedWith(ValidationError, 'custom error');
+    });
+
+    it('should pass if validator passes', async () => {
+      const value = {foo: 'bar'};
+      const instance = getInstance(schema, {key: value});
+      await validate(schema, value, ['key'], instance);
+    });
+  });
+});

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -231,6 +231,9 @@ describe('validateValue()', () => {
           if (value === 'baz') {
             throw new ValidationError('Value baz is not allowed.', 'custom', value, path, instance);
           }
+          if (value === 'throw') {
+            throw new Error('Something went horribly wrong.');
+          }
         },
       })
       public foo: any;
@@ -253,11 +256,18 @@ describe('validateValue()', () => {
         .to.be.rejectedWith(ValidationError, 'Value is not an instance of NestedModel.');
     });
 
-    it('should throw a ValidationError if nested model\'s validator throws', async () => {
+    it('should throw a ValidationError if nested model\'s validator throws ValidationError', async () => {
       const value = new NestedModel({foo: 'baz'});
       const instance = getInstance(schema, {key: value});
       await expect(validateValue(schema, value, ['key'], instance))
         .to.be.rejectedWith(ValidationError, 'Value baz is not allowed.');
+    });
+
+    it('should throw an Error if nested model\'s validator throws Error', async () => {
+      const value = new NestedModel({foo: 'throw'});
+      const instance = getInstance(schema, {key: value});
+      await expect(validateValue(schema, value, ['key'], instance))
+        .to.be.rejectedWith(Error, 'Something went horribly wrong.');
     });
 
     it('should throw a ValidationError if custom validator throws', async () => {

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -1,0 +1,52 @@
+import { ValidationError } from './errors';
+import { Model } from './model';
+import { SchemaValue } from './schema';
+
+export async function validate(
+  schema: SchemaValue,
+  value: any,
+  path: Array<string | number>,
+  instance: Model<object>,
+) {
+  if (schema.required && value === undefined) {
+    throw new ValidationError(
+      'Required value is undefined.',
+      'required',
+      value,
+      path,
+      instance,
+    );
+  }
+
+  // nothing to validate if undefined
+  if (value === undefined) {
+    return;
+  }
+
+  switch (schema.type) {
+    case 'any':
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
+
+    case 'array':
+      if (!(value instanceof Array)) {
+        throw new ValidationError('Value is not an array.', 'no-array', value, path, instance);
+      }
+
+      // validate all elements
+      await Promise.all(value.map(async (element, index) => {
+        const newPath = path.slice();
+        newPath.push(index);
+        await validate(schema.definition, element, newPath, instance);
+      }));
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
+  }
+}

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -166,7 +166,7 @@ export async function validateValue(
 
     case 'object':
       if (!(value instanceof Object)) {
-        throw new ValidationError('Value is not an object.', 'no-number', value, path, instance);
+        throw new ValidationError('Value is not an object.', 'no-object', value, path, instance);
       }
 
       await validateObject(schema.definition, value, path, instance);
@@ -195,7 +195,43 @@ export async function validateValue(
 
       break;
 
+    case 'string':
+      if (typeof value !== 'string') {
+        throw new ValidationError('Value is not a string.', 'no-string', value, path, instance);
+      }
+
+      if (schema.enum && schema.enum.indexOf(value) === -1) {
+        throw new ValidationError(
+          `String not in enum: ${schema.enum.join(', ')}.`,
+          'string-enum', value, path, instance,
+        );
+      }
+
+      if (schema.min && value.length < schema.min) {
+        throw new ValidationError(
+          `String must not have less than ${schema.min} characters.`,
+          'string-min', value, path, instance,
+        );
+      }
+
+      if (schema.max && value.length > schema.max) {
+        throw new ValidationError(
+          `String must not have more than ${schema.max} characters.`,
+          'string-max', value, path, instance,
+        );
+      }
+
+      if (schema.regex && !schema.regex.test(value)) {
+        throw new ValidationError(`String does not match regex.`, 'string-regex', value, path, instance);
+      }
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
+
     default:
-      throw new Error(`type ${schema.type} is unknown.`);
+      throw new Error(`type ${(schema as SchemaValue).type} is unknown.`);
   }
 }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -36,6 +36,20 @@ export async function validate(
         throw new ValidationError('Value is not an array.', 'no-array', value, path, instance);
       }
 
+      if (schema.minLength !== undefined && value.length < schema.minLength) {
+        throw new ValidationError(
+          `Array must have at least ${schema.minLength} elements.`,
+          'array-min-length', value, path, instance,
+        );
+      }
+
+      if (schema.maxLength !== undefined && value.length > schema.maxLength) {
+        throw new ValidationError(
+          `Array must have at most ${schema.maxLength} elements.`,
+          'array-max-length', value, path, instance,
+        );
+      }
+
       // validate all elements
       await Promise.all(value.map(async (element, index) => {
         const newPath = path.slice();

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -62,5 +62,16 @@ export async function validate(
       }
 
       break;
+
+    case 'boolean':
+      if (value !== true && value !== false) {
+        throw new ValidationError('Value is not a boolean.', 'no-boolean', value, path, instance);
+      }
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
   }
 }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -126,8 +126,17 @@ export async function validateValue(
           'no-instance', value, path, instance,
         );
       }
-      // TODO: use value.validate() so we use the same validation we'd get on the instance
-      await validateObject(schema.model._schema, value, path, instance);
+
+      try {
+        await value.validate();
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          const newPath = path.concat(error.path);
+          throw new ValidationError(error.message, error.reason, error.value, newPath, instance);
+        }
+
+        throw error;
+      }
 
       if (schema.validate) {
         await schema.validate(value, path, instance);

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -28,6 +28,23 @@ export async function validateObject(
   }));
 }
 
+async function runCustomValidator<T>(schema, value: T, path, instance) {
+  try {
+    if (schema.validate) {
+      await schema.validate(value, path, instance);
+    }
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      error.reason = error.reason || 'custom';
+      error.value = error.value || value;
+      error.path = error.path || path;
+      error.instance = error.instance || instance;
+      throw error;
+    }
+    throw error;
+  }
+}
+
 export async function validateValue(
   schema: SchemaValue,
   value: any,
@@ -51,9 +68,7 @@ export async function validateValue(
 
   switch (schema.type) {
     case 'any':
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -83,9 +98,7 @@ export async function validateValue(
         await validateValue(schema.definition, element, newPath, instance);
       }));
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -94,9 +107,7 @@ export async function validateValue(
         throw new ValidationError('Value is not a boolean.', 'no-boolean', value, path, instance);
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -113,9 +124,7 @@ export async function validateValue(
         throw new ValidationError(`Date must not be after ${schema.max}.`, 'date-max', value, path, instance);
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -138,9 +147,7 @@ export async function validateValue(
         throw error;
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -167,9 +174,7 @@ export async function validateValue(
         );
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -180,9 +185,7 @@ export async function validateValue(
 
       await validateObject(schema.definition, value, path, instance);
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -198,9 +201,7 @@ export async function validateValue(
         );
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 
@@ -234,9 +235,7 @@ export async function validateValue(
         throw new ValidationError(`String does not match regex.`, 'string-regex', value, path, instance);
       }
 
-      if (schema.validate) {
-        await schema.validate(value, path, instance);
-      }
+      await runCustomValidator(schema, value, path, instance);
 
       break;
 

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -177,6 +177,24 @@ export async function validateValue(
 
       break;
 
+    case 'reference':
+      // note: we do not run validation on a populated reference since it's not part of
+      //       the model instance
+
+      const collection = schema.collection();
+      if (typeof value !== 'string' && !(value instanceof collection.model)) {
+        throw new ValidationError(
+          `Value is not an id or ${collection.model.name} instance.`,
+          'no-number', value, path, instance,
+        );
+      }
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
+
     default:
       throw new Error(`type ${schema.type} is unknown.`);
   }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -232,6 +232,6 @@ export async function validateValue(
       break;
 
     default:
-      throw new Error(`type ${(schema as SchemaValue).type} is unknown.`);
+      throw new Error(`Type ${(schema as SchemaValue).type} is unknown.`);
   }
 }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -73,5 +73,24 @@ export async function validate(
       }
 
       break;
+
+    case 'date':
+      if (!(value instanceof Date)) {
+        throw new ValidationError('Value is not a date.', 'no-date', value, path, instance);
+      }
+
+      if (schema.min && value < schema.min) {
+        throw new ValidationError(`Date must not be before ${schema.min}.`, 'date-min', value, path, instance);
+      }
+
+      if (schema.max && value > schema.max) {
+        throw new ValidationError(`Date must not be after ${schema.max}.`, 'date-max', value, path, instance);
+      }
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
   }
 }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -109,8 +109,37 @@ export async function validateValue(
           'no-instance', value, path, instance,
         );
       }
-
+      // TODO: use value.validate() so we use the same validation we'd get on the instance
       await validateObject(schema.model._schema, value, path, instance);
+
+      if (schema.validate) {
+        await schema.validate(value, path, instance);
+      }
+
+      break;
+
+    case 'number':
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new ValidationError('Value is not a number.', 'no-number', value, path, instance);
+      }
+
+      if (schema.integer && !Number.isInteger(value)) {
+        throw new ValidationError('Number is not an integer.', 'no-integer', value, path, instance);
+      }
+
+      if (schema.min !== undefined && value < schema.min) {
+        throw new ValidationError(
+          `Number must not be less than ${schema.min}.`,
+          'number-min', value, path, instance,
+        );
+      }
+
+      if (schema.max !== undefined && value > schema.max) {
+        throw new ValidationError(
+          `Number must not be greater than ${schema.max}.`,
+          'number-max', value, path, instance,
+        );
+      }
 
       if (schema.validate) {
         await schema.validate(value, path, instance);

--- a/test-init.js
+++ b/test-init.js
@@ -1,8 +1,10 @@
 require('ts-node').register();
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinonChai = require('sinon-chai');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 
 // expose global variable 'expect'
 expect = chai.expect;


### PR DESCRIPTION
* Add `validate()` to `Model` for all supported schema types. Validator functions are async and run in parallel down the object/array tree (learned from `mongoose` quirky async validator handling).
* All validation options that mongoose supports are supported in octonom schemas (and a couple more):
  * all types: `required` and `validate` (custom validator)
  * `array`: `minLength` and `maxLength`
  * `date`: `min` and `max`
  * `number`: `min`, `max`, and `integer`
  * `string`: `enum`, `min`, `max`, and `regex`
* `validate()` throws an `ValidationError` that has the properties `message`, `value`, `reason`, `path`, `instance` for convenient error handling.