### PR TITLE
Use Proxy instead of defineProperty hackery

### DIFF
--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -33,6 +33,13 @@ describe('Model', () => {
         cat.name = 'Yllim';
         expect(cat.name).to.equal('Yllim');
       });
+
+      it('should delete a property', () => {
+        const cat = new CatModel();
+        cat.id = '42';
+        delete cat.id;
+        expect(cat.id).to.equal(undefined);
+      });
     });
 
     describe('toObject()', () => {

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -1,8 +1,8 @@
-import { cloneDeep, difference, forEach } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { IPopulateMap, populateObject } from './populate';
 import { ISchemaSanitizeOptions, ISchemaToObjectOptions, sanitize,
-         SchemaMap, SchemaValue, toObject } from './schema';
+         SchemaMap, SchemaValue, setObjectSanitized, toObject } from './schema';
 import { validateObject } from './validate';
 
 export interface IModelConstructor<TModel extends Model<object>> {
@@ -12,26 +12,10 @@ export interface IModelConstructor<TModel extends Model<object>> {
 
 interface IModel {
   constructor: typeof Model;
-  _sanitized: {[k: string]: object};
-  setKey(key: string, value: any, options?: ISchemaSanitizeOptions);
-}
-
-function defineModelProperty(target, key: string, enumerable: boolean) {
-  Object.defineProperty(target, key, {
-    configurable: true,
-    enumerable,
-    get() {
-      return this._sanitized[key];
-    },
-    set(value) {
-      const instance = this as IModel;
-      instance.setKey(key, value);
-    },
-  });
 }
 
 export abstract class Model<T extends object> {
-  public static _schema: SchemaMap = {};
+  public static _schema: SchemaMap;
 
   /**
    * Attach schema information to the property
@@ -40,22 +24,26 @@ export abstract class Model<T extends object> {
   public static PropertySchema(schema: SchemaValue): PropertyDecorator {
     return (target: IModel, key: string) => {
       const constructor = target.constructor;
-      constructor._schema = cloneDeep(constructor._schema);
+      constructor._schema = cloneDeep(constructor._schema || {});
       constructor._schema[key] = schema;
-
-      // define model property
-      defineModelProperty(target, key, false);
     };
   }
 
-  // TODO: make this work
-  // @enumerable(false)
-  protected _sanitized = {};
-
   constructor(data?: Partial<T>) {
-    // TODO: remove (see @enumerable decorator)
-    Object.defineProperty(this, '_sanitized', {writable: true, enumerable: false});
+    const constructor = this.constructor as typeof Model;
+    const schema = constructor._schema;
+
+    // set initial data
     this.set(data || {}, {defaults: true, replace: true});
+
+    // create proxy that intercepts set operations
+    // for running sanitization if the key is in the schema
+    return new Proxy(this, {
+      set(target, key, value, receiver) {
+        target[key] = schema[key] ? sanitize(schema[key], value) : value;
+        return true;
+      },
+    });
   }
 
   public inspect() {
@@ -67,41 +55,10 @@ export abstract class Model<T extends object> {
     return populateObject(this, constructor._schema, populateMap);
   }
 
-  // TODO: find a way to merge this with setObjectSanitized, code is pretty redundant
+  // TODO: sanitize is called twice when this is called via the proxy
   public set(data: object, options: ISchemaSanitizeOptions = {}) {
     const constructor = this.constructor as typeof Model;
-
-    if (typeof data !== 'object') {
-      throw new Error('data is not an object');
-    }
-
-    const dataKeys = Object.keys(data);
-    const schemaKeys = Object.keys(constructor._schema);
-    const disallowedKeys = difference(dataKeys, schemaKeys);
-    if (disallowedKeys.length > 0) {
-      throw new Error(`key ${disallowedKeys[0]} not found in schema`);
-    }
-
-    forEach(constructor._schema, (_, key) => {
-      if (data[key] === undefined && !options.replace) {
-        return;
-      }
-      this.setKey(key, data[key], options);
-    });
-  }
-
-  public setKey(key: string, value: any, options: ISchemaSanitizeOptions = {}) {
-    const constructor = this.constructor as typeof Model;
-    const schemaValue = constructor._schema[key];
-
-    if (!schemaValue) {
-      throw new Error(`key ${key} not found in schema`);
-    }
-
-    const sanitizedValue = sanitize(schemaValue, value, options);
-    this._sanitized[key] = sanitizedValue;
-
-    defineModelProperty(this, key, sanitizedValue !== undefined);
+    setObjectSanitized(constructor._schema, this, data, options);
   }
 
   public toObject(options?: ISchemaToObjectOptions): Partial<T> {

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -20,12 +20,10 @@ function defineModelProperty(target, key: string, enumerable: boolean) {
   Object.defineProperty(target, key, {
     configurable: true,
     enumerable,
-    // tslint:disable-next-line:object-literal-shorthand
-    get: function() {
+    get() {
       return this._sanitized[key];
     },
-    // tslint:disable-next-line:object-literal-shorthand
-    set: function(value) {
+    set(value) {
       const instance = this as IModel;
       instance.setKey(key, value);
     },

--- a/packages/octonom/lib/schema.ts
+++ b/packages/octonom/lib/schema.ts
@@ -218,11 +218,14 @@ export function setObjectSanitized(schemaMap: ISchemaMap, target: object, data: 
       delete target[key];
     }
 
-    if (dataKeys.indexOf(key) === -1) {
+    if (data[key] === undefined && !options.replace) {
       return;
     }
 
-    target[key] = sanitize(schemaValue, data[key], options);
+    const sanitizedValue = sanitize(schemaValue, data[key], options);
+    if (sanitizedValue !== undefined) {
+      target[key] = sanitizedValue;
+    }
   });
 
   return target;


### PR DESCRIPTION
This PR removes most of the evil magic in the `Model` class. Instead of defining property getter/setter that redirect get/set operations to another object we now simply intercept set operations with a `Proxy`. :metal: 

Fixes #26.