### PR TITLE
Remove generic parameter from Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Let's define a model:
 ```typescript
 import { Model } from 'octonom';
 
-export class PersonModel extends Model<PersonModel> {
+export class Person extends Model {
   @Model.Property({type: 'string', default: () => '42'})
   public id: string;
 
@@ -57,7 +57,7 @@ Let's create an instance:
 
 ```typescript
 // create an instance with initial data
-const person = new PersonModel({name: 'Marx', age: 200});
+const person = new Person({name: 'Marx', age: 200});
 
 // call a model instance method
 person.makeOlder();
@@ -79,7 +79,7 @@ import { MongoClient } from 'mongodb';
 import { MongoCollection } from 'octonom';
 
 // create people collection
-const people = new MongoCollection('people', PersonModel, {modelIdField: 'id'});
+const people = new MongoCollection('people', Person, {modelIdField: 'id'});
 
 // connect with to database
 const db = await MongoClient.connect('mongodb://localhost:27017/mydb');
@@ -92,7 +92,7 @@ Inserting and retrieving models is straight-forward:
 
 ```typescript
 // insert a person
-const karl = new PersonModel({id: 'C4p1T4l', name: 'Marx', age: 200});
+const karl = new Person({id: 'C4p1T4l', name: 'Marx', age: 200});
 await people.insertOne(karl);
 
 // retrieve a person

--- a/packages/octonom/lib/array-collection.ts
+++ b/packages/octonom/lib/array-collection.ts
@@ -5,14 +5,14 @@ import { Model } from './model';
 
 // simple collection with an in-memory array
 // note: we can't test Collection directly since it's abstract
-export class ArrayCollection<TModel extends Model<object>> extends Collection<TModel> {
+export class ArrayCollection<T extends Model> extends Collection<T> {
   public array: object[] = [];
 
   public clear() {
     this.array.splice(0, this.array.length);
   }
 
-  public insert(model: TModel) {
+  public insert(model: T) {
     const doc = find(this.array, {[this.modelIdField]: model[this.modelIdField]});
     if (doc) {
       throw new Error('duplicate key error');

--- a/packages/octonom/lib/collection.ts
+++ b/packages/octonom/lib/collection.ts
@@ -5,31 +5,31 @@ export interface ICollectionOptions {
   modelIdField?: string;
 }
 
-export abstract class Collection<TModel extends Model<object>> {
+export abstract class Collection<T extends Model> {
   public readonly modelIdField: string;
 
   constructor(
-    public readonly model: IModelConstructor<TModel>,
+    public readonly model: IModelConstructor<T>,
     protected options: ICollectionOptions = {},
   ) {
     this.modelIdField = options.modelIdField || 'id';
   }
 
-  public abstract async findById(id: string): Promise<TModel>;
+  public abstract async findById(id: string): Promise<T>;
 
   // trivial implementation, should be implemented efficiently for specific database
-  public async findByIds(ids: string[]): Promise<ModelArray<TModel>> {
-    return new ModelArray<TModel>(
+  public async findByIds(ids: string[]): Promise<ModelArray<T>> {
+    return new ModelArray<T>(
       this.model,
       await Promise.all(ids.map(id => this.findById(id))),
     );
   }
 
-  public toDb(model: TModel): object {
+  public toDb(model: T): object {
     return model.toObject({unpopulate: true});
   }
 
-  public fromDb(doc: object): TModel {
+  public fromDb(doc: object): T {
     return new this.model(doc);
   }
 }

--- a/packages/octonom/lib/errors.ts
+++ b/packages/octonom/lib/errors.ts
@@ -15,7 +15,7 @@ export class ValidationError extends ExtendableError {
     public reason?: string,
     public value?: any,
     public path?: Array<string | number>,
-    public instance?: Model<object>,
+    public instance?: Model,
   ) {
     super(message, ValidationError.prototype);
   }

--- a/packages/octonom/lib/model-array.ts
+++ b/packages/octonom/lib/model-array.ts
@@ -1,9 +1,9 @@
 import { IModelConstructor, Model } from './model';
 
-export class ModelArray<TModel extends Model<object>> extends Array<TModel> {
+export class ModelArray<T extends Model> extends Array<T> {
   constructor(
-    public readonly model: IModelConstructor<TModel>,
-    data: Array<Partial<TModel>> = [],
+    public readonly model: IModelConstructor<T>,
+    data: Array<Partial<T>> = [],
   ) {
     super();
     data.forEach(element => this.push(element));
@@ -21,30 +21,30 @@ export class ModelArray<TModel extends Model<object>> extends Array<TModel> {
     });
   }
 
-  public fill(value: Partial<TModel>, start?: number, end?: number) {
+  public fill(value: Partial<T>, start?: number, end?: number) {
     return super.fill(this.toModel(value), start, end);
   }
 
-  public push(value: Partial<TModel>) {
+  public push(value: Partial<T>) {
     return super.push(this.toModel(value));
   }
 
-  public splice(start: number, deleteCount?: number, ...values: Array<Partial<TModel>>) {
+  public splice(start: number, deleteCount?: number, ...values: Array<Partial<T>>) {
     const models = values ? values.map(value => this.toModel(value)) : [];
     return super.splice(start, deleteCount, ...models);
   }
 
-  public toModel(value: Partial<TModel>) {
+  public toModel(value: Partial<T>) {
     if (value === undefined) {
       return undefined;
     }
 
     return value instanceof this.model
-      ? value as TModel
+      ? value as T
       : new this.model(value);
   }
 
-  public unshift(...values: Array<Partial<TModel>>) {
+  public unshift(...values: Array<Partial<T>>) {
     const models = values ? values.map(value => this.toModel(value)) : [];
     return super.unshift(...models);
   }

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -374,7 +374,7 @@ describe('Model', () => {
   });
 
   describe('validate()', () => {
-    class TestModel extends Model<TestModel> {
+    class TestModel extends Model {
       @Model.Property({type: 'string', required: true})
       public required: string;
 

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -6,16 +6,16 @@ import { SchemaMap, SchemaValue } from './schema';
 import { IToObjectOptions, toObject } from './to-object';
 import { validateObject } from './validate';
 
-export interface IModelConstructor<TModel extends Model<object>> {
+export interface IModelConstructor<T extends Model> {
   schema: SchemaMap;
-  new (data: Partial<TModel>): TModel;
+  new (data: Partial<T>): T;
 }
 
 interface IModel {
   constructor: typeof Model;
 }
 
-export abstract class Model<T extends object> {
+export abstract class Model {
   public static schema: SchemaMap;
 
   /**
@@ -30,7 +30,8 @@ export abstract class Model<T extends object> {
     };
   }
 
-  constructor(data?: Partial<T>) {
+  // TODO: ideally we'd also use Partial<this> as the type for data
+  constructor(data?) {
     const constructor = this.constructor as typeof Model;
     const schema = constructor.schema;
 
@@ -57,14 +58,14 @@ export abstract class Model<T extends object> {
   }
 
   // TODO: sanitize is called twice when this is called via the proxy
-  public set(data: object, options: ISanitizeOptions = {}) {
+  public set(data: Partial<this>, options: ISanitizeOptions = {}) {
     const constructor = this.constructor as typeof Model;
     setObjectSanitized(constructor.schema, this, data, options);
   }
 
-  public toObject(options?: IToObjectOptions): Partial<T> {
+  public toObject(options?: IToObjectOptions): Partial<this> {
     const constructor = this.constructor as typeof Model;
-    return toObject(constructor.schema, this, options) as Partial<T>;
+    return toObject(constructor.schema, this, options) as Partial<this>;
   }
 
   public toJSON() {

--- a/packages/octonom/lib/sanitize.spec.ts
+++ b/packages/octonom/lib/sanitize.spec.ts
@@ -55,7 +55,7 @@ describe('sanitize()', () => {
   });
 
   describe('type model', () => {
-    class Cat extends Model<Cat> {
+    class Cat extends Model {
       @Cat.Property({type: 'string'})
       public name: string;
     }
@@ -124,7 +124,7 @@ describe('sanitize()', () => {
   });
 
   describe('type reference', () => {
-    class Cat extends Model<Cat> {
+    class Cat extends Model {
       @Cat.Property({type: 'string'})
       public id: string;
 

--- a/packages/octonom/lib/schema.ts
+++ b/packages/octonom/lib/schema.ts
@@ -8,7 +8,7 @@ export interface ISchemaValueBase {
 export interface ISchemaValueAny extends ISchemaValueBase {
   type: 'any';
   default?: () => any;
-  validate?(value: any, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: any, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueArray extends ISchemaValueBase {
@@ -16,13 +16,13 @@ export interface ISchemaValueArray extends ISchemaValueBase {
   definition: SchemaValue;
   minLength?: number;
   maxLength?: number;
-  validate?(value: any[], path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: any[], path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueBoolean extends ISchemaValueBase {
   type: 'boolean';
   default?: boolean | (() => boolean);
-  validate?(value: boolean, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: boolean, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueDate extends ISchemaValueBase {
@@ -30,13 +30,13 @@ export interface ISchemaValueDate extends ISchemaValueBase {
   default?: Date | (() => Date);
   min?: Date;
   max?: Date;
-  validate?(value: Date, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: Date, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueModel extends ISchemaValueBase {
   type: 'model';
-  model: IModelConstructor<Model<object>>;
-  validate?(value: Model<object>, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  model: IModelConstructor<Model>;
+  validate?(value: Model, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueNumber extends ISchemaValueBase {
@@ -45,19 +45,19 @@ export interface ISchemaValueNumber extends ISchemaValueBase {
   min?: number;
   max?: number;
   integer?: boolean;
-  validate?(value: number, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: number, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueObject extends ISchemaValueBase {
   type: 'object';
   definition: ISchemaMap;
-  validate?(value: object, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: object, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueReference extends ISchemaValueBase {
   type: 'reference';
   collection: () => any; // TODO
-  validate?(value: any, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: any, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export interface ISchemaValueString extends ISchemaValueBase {
@@ -67,7 +67,7 @@ export interface ISchemaValueString extends ISchemaValueBase {
   min?: number;
   max?: number;
   regex?: RegExp;
-  validate?(value: string, path: Array<string | number>, instance: Model<any>): Promise<void>;
+  validate?(value: string, path: Array<string | number>, instance: Model): Promise<void>;
 }
 
 export type SchemaValue = ISchemaValueAny | ISchemaValueArray | ISchemaValueBoolean |

--- a/packages/octonom/lib/to-object.spec.ts
+++ b/packages/octonom/lib/to-object.spec.ts
@@ -15,7 +15,7 @@ describe('toObject()', () => {
 });
 
 describe('toObjectValue()', () => {
-  class Cat extends Model<Cat> {
+  class Cat extends Model {
     @Cat.Property({type: 'string'})
     public id: string;
 

--- a/packages/octonom/lib/validate.spec.ts
+++ b/packages/octonom/lib/validate.spec.ts
@@ -7,7 +7,7 @@ import { SchemaMap, SchemaValue } from './schema';
 import { validateObject, validateValue } from './validate';
 
 function getInstance(schema: SchemaValue, data: object) {
-  class TestModel extends Model<TestModel> {
+  class TestModel extends Model {
     @Model.Property(schema)
     public key: any;
   }
@@ -62,7 +62,7 @@ describe('validateValue()', () => {
   describe('type any', () => {
     const schema: SchemaValue = {
       type: 'any',
-      validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: any, path: Array<string | number>, instance: Model) => {
         if (value.foo === 'invalid') {
           throw new ValidationError('Custom error.', 'custom', value, path, instance);
         }
@@ -88,7 +88,7 @@ describe('validateValue()', () => {
       type: 'array',
       definition: {
         type: 'any',
-        validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+        validate: async (value: any, path: Array<string | number>, instance: Model) => {
           if (value === 'invalid') {
             throw new ValidationError('Custom error.', 'custom', value, path, instance);
           }
@@ -96,7 +96,7 @@ describe('validateValue()', () => {
       },
       minLength: 1,
       maxLength: 2,
-      validate: async (value: any[], path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: any[], path: Array<string | number>, instance: Model) => {
         if (value.indexOf('baz') !== -1) {
           throw new ValidationError('Array must not contain baz.', 'custom', value, path, instance);
         }
@@ -148,7 +148,7 @@ describe('validateValue()', () => {
   describe('type boolean', () => {
     const schema: SchemaValue = {
       type: 'boolean',
-      validate: async (value: boolean, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: boolean, path: Array<string | number>, instance: Model) => {
         if (value === false) {
           throw new ValidationError('False not allowed.', 'custom', value, path, instance);
         }
@@ -181,7 +181,7 @@ describe('validateValue()', () => {
       type: 'date',
       min: new Date('2000-01-01'),
       max: new Date('2018-01-01'),
-      validate: async (value: Date, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: Date, path: Array<string | number>, instance: Model) => {
         if (value.getTime() === new Date('2017-09-03').getTime()) {
           throw new ValidationError('2017-09-03 is not allowed.', 'custom', value, path, instance);
         }
@@ -224,10 +224,10 @@ describe('validateValue()', () => {
   });
 
   describe('type model', () => {
-    class NestedModel extends Model<NestedModel> {
+    class NestedModel extends Model {
       @Model.Property({
         type: 'any',
-        validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+        validate: async (value: any, path: Array<string | number>, instance: Model) => {
           if (value === 'baz') {
             throw new ValidationError('Value baz is not allowed.', 'custom', value, path, instance);
           }
@@ -245,7 +245,7 @@ describe('validateValue()', () => {
     const schema: SchemaValue = {
       type: 'model',
       model: NestedModel,
-      validate: async (value: NestedModel, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: NestedModel, path: Array<string | number>, instance: Model) => {
         if (value.foo === 'invalid') {
           throw new ValidationError('Value invalid is not allowed.', 'custom', value, path, instance);
         }
@@ -306,7 +306,7 @@ describe('validateValue()', () => {
       min: 1,
       max: 5,
       integer: true,
-      validate: async (value: number, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: number, path: Array<string | number>, instance: Model) => {
         if (value === 3) {
           throw new ValidationError('3 is not allowed.', 'custom', value, path, instance);
         }
@@ -359,7 +359,7 @@ describe('validateValue()', () => {
     const schema: SchemaValue = {
       type: 'object',
       definition: {foo: {type: 'any', required: true}},
-      validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: any, path: Array<string | number>, instance: Model) => {
         if (value && value.foo === 'invalid') {
           throw new ValidationError('Invalid value for key foo.', 'custom', value, path, instance);
         }
@@ -398,7 +398,7 @@ describe('validateValue()', () => {
     const schema: SchemaValue = {
       type: 'reference',
       collection: () => collections.cats,
-      validate: async (value: any, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: any, path: Array<string | number>, instance: Model) => {
         if (value === 'invalid') {
           throw new ValidationError('Invalid id.', 'custom', value, path, instance);
         }
@@ -439,7 +439,7 @@ describe('validateValue()', () => {
       min: 2, // disallows f
       max: 5, // disallows foobar
       regex: /^(f|foo|bar|baz|foobar)$/, // disallows bat
-      validate: async (value: string, path: Array<string | number>, instance: Model<any>) => {
+      validate: async (value: string, path: Array<string | number>, instance: Model) => {
         if (value === 'bar') {
           throw new ValidationError('String bar is not allowed.', 'custom', value, path, instance);
         }

--- a/packages/octonom/lib/validate.ts
+++ b/packages/octonom/lib/validate.ts
@@ -6,7 +6,7 @@ export async function validateObject(
   schemaMap: SchemaMap,
   obj: object,
   path: Array<string | number>,
-  instance: Model<object>,
+  instance: Model,
 ) {
   const keys = Object.keys(obj);
   const schemaKeys = Object.keys(schemaMap);
@@ -49,7 +49,7 @@ export async function validateValue(
   schema: SchemaValue,
   value: any,
   path: Array<string | number>,
-  instance: Model<object>,
+  instance: Model,
 ) {
   if (schema.required && value === undefined) {
     throw new ValidationError(

--- a/packages/octonom/test/data/models/cat.ts
+++ b/packages/octonom/test/data/models/cat.ts
@@ -1,6 +1,6 @@
 import { Model, utils } from '../../../lib/main';
 
-export class CatModel extends Model<CatModel> {
+export class CatModel extends Model {
   @Model.Property({type: 'string', default: utils.generateId})
   public id: string;
 

--- a/packages/octonom/test/data/models/discussion.ts
+++ b/packages/octonom/test/data/models/discussion.ts
@@ -3,7 +3,7 @@ import { Model, utils } from '../../../lib/main';
 import { collections } from '../collections';
 import { PersonModel } from './person';
 
-export class DiscussionModel extends Model<DiscussionModel> {
+export class DiscussionModel extends Model {
   @Model.Property({type: 'string', default: utils.generateId})
   public id: string;
 

--- a/packages/octonom/test/data/models/group-with-array.ts
+++ b/packages/octonom/test/data/models/group-with-array.ts
@@ -2,7 +2,7 @@ import { Model, ModelArray, utils } from '../../../lib/main';
 
 import { PersonModel } from './person';
 
-export class GroupWithArrayModel extends Model<GroupWithArrayModel> {
+export class GroupWithArrayModel extends Model {
   @Model.Property({type: 'string', default: utils.generateId})
   public id: string;
 

--- a/packages/octonom/test/data/models/group-with-references.ts
+++ b/packages/octonom/test/data/models/group-with-references.ts
@@ -3,7 +3,7 @@ import { Model, utils } from '../../../lib/main';
 import { collections } from '../collections';
 import { PersonModel } from './person';
 
-export class GroupWithReferencesModel extends Model<GroupWithReferencesModel> {
+export class GroupWithReferencesModel extends Model {
   @Model.Property({type: 'string', default: utils.generateId})
   public id: string;
 

--- a/packages/octonom/test/data/models/person-account.ts
+++ b/packages/octonom/test/data/models/person-account.ts
@@ -1,6 +1,6 @@
 import { Model } from '../../../lib/main';
 
-export class PersonAccountModel extends Model<PersonAccountModel> {
+export class PersonAccountModel extends Model {
   @Model.Property({type: 'string'})
   public username: string;
 }

--- a/packages/octonom/test/data/models/person.ts
+++ b/packages/octonom/test/data/models/person.ts
@@ -2,7 +2,7 @@ import { Model, utils } from '../../../lib/main';
 
 import { PersonAccountModel } from './person-account';
 
-export class PersonModel extends Model<PersonModel> {
+export class PersonModel extends Model {
   @Model.Property({type: 'string', default: utils.generateId})
   public id: string;
 


### PR DESCRIPTION
By using the `this` type we can get rid of the generic `Model` parameter, possibly also allowing nice mixins (see #34). Defining models is now as elegant as it can be. :stuck_out_tongue: 

## Caveat
We lose the type safety on the `data` parameter in model constructors if the derived class does not implement a constructor à la
```typescript
class Person extends Model {
  constructor(data?: Partial<Person>) {
    super(data);
  }
}
```
Issue #37 keeps track of this.