### PR TITLE
Add Hook decorator and Timestamp mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,22 +11,22 @@
     "test-cover-submit": "nyc report --reporter=json && codecov -f coverage/*.json"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.1",
+    "@types/chai": "^4.0.4",
     "@types/chai-as-promised": "7.1.0",
-    "@types/mocha": "^2.2.41",
+    "@types/mocha": "^2.2.42",
     "@types/sinon": "^2.3.3",
     "@types/sinon-chai": "^2.7.29",
-    "chai": "^4.0.2",
+    "chai": "^4.1.2",
     "chai-as-promised": "^7.0.0",
-    "codecov": "^2.2.0",
-    "lerna": "^2.1.0",
-    "mocha": "^3.4.2",
-    "nyc": "^11.0.2",
-    "sinon": "^2.4.0",
+    "codecov": "^2.3.0",
+    "lerna": "^2.1.2",
+    "mocha": "^3.5.0",
+    "nyc": "^11.2.1",
+    "sinon": "^2.4.1",
     "sinon-chai": "^2.13.0",
-    "ts-node": "^3.1.0",
-    "tslint": "^5.4.3",
-    "typescript": "^2.3.4"
+    "ts-node": "^3.3.0",
+    "tslint": "^5.7.0",
+    "typescript": "^2.5.2"
   },
   "dependencies": {
     "mongodb": "^2.2.31"

--- a/packages/octonom-timestamp/lib/main.ts
+++ b/packages/octonom-timestamp/lib/main.ts
@@ -1,0 +1,1 @@
+export { Timestamp } from './timestamp';

--- a/packages/octonom-timestamp/lib/timestamp.spec.ts
+++ b/packages/octonom-timestamp/lib/timestamp.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { Model, Property } from 'octonom';
+
+import { Timestamp } from './timestamp';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('Timestamp mixin', () => {
+  class Base extends Model {
+    @Property({type: 'string'})
+    public base: string;
+  }
+
+  function testInstance(instance) {
+    expect(instance).to.have.property('createdAt').which.is.an.instanceOf(Date);
+    expect(instance).to.have.property('updatedAt').which.is.an.instanceOf(Date);
+  }
+
+  describe('Direct mixin extending from Model', () => {
+    class Timestamped extends Timestamp(Model) {
+      @Property({type: 'string'})
+      public name: string;
+    }
+
+    it('should set createdAt and updatedAt on a new instance', () => {
+      const instance = new Timestamped();
+      testInstance(instance);
+      expect(instance.createdAt.getTime()).to.equal(instance.updatedAt.getTime());
+    });
+
+    it('should update updatedAt when calling set()', async () => {
+      const instance = new Timestamped();
+      await sleep(10);
+      instance.set({name: 'test'});
+      expect(instance.createdAt.getTime()).to.be.lessThan(instance.updatedAt.getTime());
+    });
+
+    it('should update updatedAt when setting a property', async () => {
+      const instance = new Timestamped();
+      await sleep(10);
+      instance.name = 'test';
+      expect(instance.createdAt.getTime()).to.be.lessThan(instance.updatedAt.getTime());
+    });
+
+    it('should update updatedAt when deleting a property', async () => {
+      const instance = new Timestamped({name: 'test'});
+      await sleep(10);
+      delete instance.name;
+      expect(instance.createdAt.getTime()).to.be.lessThan(instance.updatedAt.getTime());
+    });
+  });
+});

--- a/packages/octonom-timestamp/lib/timestamp.ts
+++ b/packages/octonom-timestamp/lib/timestamp.ts
@@ -1,0 +1,52 @@
+import { Hooks, Model } from 'octonom';
+
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
+// TODO: remove the interface wizardry when https://github.com/Microsoft/TypeScript/pull/15932
+//       landed in a typescript release
+export interface ITimestamp {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ITimestampStatic {
+  new (...args: any[]): ITimestamp;
+}
+
+export function Timestamp<T extends Constructor<Model>>(base: T): ITimestampStatic & T {
+  const newClass = class extends base {
+    public createdAt: Date;
+    public updatedAt: Date;
+  };
+
+  // ideally we'd use the decorator on the property as usual but
+  // typescript doesn't like this yet, see
+  // https://github.com/Microsoft/TypeScript/issues/7342
+  Model.Property({type: 'date'})(newClass.prototype, 'createdAt');
+  Model.Property({type: 'date'})(newClass.prototype, 'updatedAt');
+  Hooks<ITimestamp & Model>({
+    afterSet: (instance: any, data) => {
+      console.log('afterSet', instance, data)
+      const date = new Date();
+
+      const properties: {createdAt?: Date, updatedAt?: Date} = {};
+
+      if (!instance.createdAt) {
+        properties.createdAt = date;
+      }
+
+      // update if updatedAt isn't set or if the provided data doesn't set it
+      if (!instance.updatedAt || Object.keys(data).indexOf('updatedAt') === -1) {
+        properties.updatedAt = date;
+      }
+
+      if (instance.name !== 'lol') {
+        instance.name = 'lol';
+      }
+
+      Object.assign(instance, properties);
+    },
+  })(newClass as any);
+
+  return newClass;
+}

--- a/packages/octonom-timestamp/lib/timestamp.ts
+++ b/packages/octonom-timestamp/lib/timestamp.ts
@@ -1,4 +1,4 @@
-import { Hooks, Model } from 'octonom';
+import { Hook, Model } from 'octonom';
 
 export type Constructor<T = {}> = new (...args: any[]) => T;
 
@@ -19,33 +19,19 @@ export function Timestamp<T extends Constructor<Model>>(base: T): ITimestampStat
     public updatedAt: Date;
   };
 
-  // ideally we'd use the decorator on the property as usual but
+  // ideally we'd use the decorators on the property as usual but
   // typescript doesn't like this yet, see
   // https://github.com/Microsoft/TypeScript/issues/7342
   Model.Property({type: 'date'})(newClass.prototype, 'createdAt');
   Model.Property({type: 'date'})(newClass.prototype, 'updatedAt');
-  Hooks<ITimestamp & Model>({
-    afterSet: (instance: any, data) => {
-      console.log('afterSet', instance, data)
-      const date = new Date();
+  Hook<ITimestamp & Model, 'afterSet'>('afterSet', ({instance, data}) => {
+    const date = new Date();
 
-      const properties: {createdAt?: Date, updatedAt?: Date} = {};
+    if (!instance.createdAt) {
+      instance.createdAt = date;
+    }
 
-      if (!instance.createdAt) {
-        properties.createdAt = date;
-      }
-
-      // update if updatedAt isn't set or if the provided data doesn't set it
-      if (!instance.updatedAt || Object.keys(data).indexOf('updatedAt') === -1) {
-        properties.updatedAt = date;
-      }
-
-      if (instance.name !== 'lol') {
-        instance.name = 'lol';
-      }
-
-      Object.assign(instance, properties);
-    },
+    instance.updatedAt = date;
   })(newClass as any);
 
   return newClass;

--- a/packages/octonom-timestamp/package.json
+++ b/packages/octonom-timestamp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "octonom-timestamp",
+  "version": "1.0.0-alpha.1",
+  "description": "Timestamp mixin for Octonom models",
+  "main": "build/lib/main.js",
+  "types": "build/lib/main.d.ts",
+  "scripts": {
+    "build": "rm -rf ./build && tsc -p tsconfig.build.json",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "octonom-plugin",
+    "mixin",
+    "timestamp",
+    "ODM",
+    "ORM",
+    "document",
+    "object",
+    "model"
+  ],
+  "author": "André Gaul <andre@paperhive.org>",
+  "license": "MIT",
+  "repository": "paperhive/octonom",
+  "bugs": "https://github.com/paperhive/octonom/issues",
+  "dependencies": {
+    "octonom": "^1.0.0-alpha.13",
+    "ts-node": "^3.3.0"
+  }
+}

--- a/packages/octonom-timestamp/tsconfig.build.json
+++ b/packages/octonom-timestamp/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "./"
+  }
+}

--- a/packages/octonom/lib/hooks.spec.ts
+++ b/packages/octonom/lib/hooks.spec.ts
@@ -1,0 +1,24 @@
+import { spy } from 'sinon';
+
+import { CatModel } from '../test/data/models/cat';
+import { Hooks, ISetHookOptions } from './hooks';
+
+describe('Hooks', () => {
+  const cat = new CatModel();
+  it('should copy handlers in the constructor', () => {
+    const hooks = new Hooks<CatModel>();
+    const handler = (options: ISetHookOptions<CatModel>) => undefined;
+    hooks.register('beforeSet', handler);
+    const newHooks = new Hooks<CatModel>(hooks);
+    expect((newHooks as any).handlers.beforeSet).to.eql([handler]);
+  });
+
+  it('should register and run a handler', () => {
+    const hooks = new Hooks<CatModel>();
+    const handler = spy();
+    hooks.register('beforeSet', handler);
+    const options = {instance: cat, data: {name: 'Yllim'}};
+    hooks.run('beforeSet', options);
+    expect(handler).to.be.calledOnce.and.calledWith(options);
+  });
+});

--- a/packages/octonom/lib/hooks.ts
+++ b/packages/octonom/lib/hooks.ts
@@ -1,0 +1,65 @@
+import { Collection } from './collection';
+import { Model } from './model';
+import { ISanitizeOptions } from './sanitize';
+
+export class HookHandlers<THookOptions, TModel extends Model> {
+  private handlers: Array<(options: THookOptions) => void> = [];
+
+  public register(handler: (options: THookOptions) => void) {
+    this.handlers.push(handler);
+  }
+
+  public run(options: THookOptions) {
+    this.handlers.forEach(handler => handler(options));
+  }
+}
+
+export interface ISetHookOptions<TModel extends Model> {
+  instance: TModel;
+  data: Partial<TModel>;
+  options?: ISanitizeOptions;
+}
+
+export interface ISaveHookOptions<TModel extends Model> {
+  instance: TModel;
+  collection: Collection<TModel>;
+}
+
+export type hookHandler<THookOptions> = (options: THookOptions) => void;
+
+export interface IHookOptionMap<TModel extends Model> {
+  beforeSet: ISetHookOptions<TModel>;
+  afterSet: ISetHookOptions<TModel>;
+  beforeSave: ISaveHookOptions<TModel>;
+  afterSave: ISaveHookOptions<TModel>;
+}
+
+export type handlerNames<TModel extends Model> = keyof IHookOptionMap<TModel>;
+
+export type HookHandlerMap<TModel extends Model> = {
+  [k in handlerNames<TModel>]: (options: IHookOptionMap<TModel>[k]) => void;
+};
+
+export type HookHandlersMap<TModel extends Model> = {
+  [k in handlerNames<TModel>]: Array<HookHandlerMap<TModel>[k]>;
+};
+
+export class Hooks<TModel extends Model> {
+  private handlers: HookHandlersMap<TModel> = {
+    beforeSet: [],
+    afterSet: [],
+    beforeSave: [],
+    afterSave: [],
+  };
+
+  public add<K extends keyof HookHandlersMap<TModel>>(name: K, handler: HookHandlersMap<TModel>[K][0]) {
+    this.handlers[name] = this.handlers[name].slice();
+    const handlers = this.handlers[name] as Array<HookHandlersMap<TModel>[K][0]>;
+    handlers.push(handler);
+  }
+
+  public run<K extends keyof IHookOptionMap<TModel>>(name: K, options: IHookOptionMap<TModel>[K]) {
+    const handlers = this.handlers[name] as Array<HookHandlersMap<TModel>[K][0]>;
+    handlers.forEach(handler => handler(options));
+  }
+}

--- a/packages/octonom/lib/hooks.ts
+++ b/packages/octonom/lib/hooks.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from 'lodash';
-
 import { Collection } from './collection';
 import { Model } from './model';
 import { ISanitizeOptions } from './sanitize';

--- a/packages/octonom/lib/hooks.ts
+++ b/packages/octonom/lib/hooks.ts
@@ -46,7 +46,6 @@ export class Hooks<TModel extends Model> {
   }
 
   public register<K extends keyof HookHandlersMap<TModel>>(name: K, handler: HookHandlersMap<TModel>[K][0]) {
-    this.handlers[name] = this.handlers[name].slice();
     const handlers = this.handlers[name] as Array<HookHandlersMap<TModel>[K][0]>;
     handlers.push(handler);
   }

--- a/packages/octonom/lib/main.ts
+++ b/packages/octonom/lib/main.ts
@@ -3,6 +3,6 @@ import * as utils from './utils';
 export { ArrayCollection } from './array-collection';
 export { Collection, ICollectionOptions } from './collection';
 export { ValidationError } from './errors';
-export { IModelConstructor, Model, Property } from './model';
+export { Hook, IModelConstructor, Model, Property } from './model';
 export { ModelArray } from './model-array';
 export { utils };

--- a/packages/octonom/lib/main.ts
+++ b/packages/octonom/lib/main.ts
@@ -3,6 +3,6 @@ import * as utils from './utils';
 export { ArrayCollection } from './array-collection';
 export { Collection, ICollectionOptions } from './collection';
 export { ValidationError } from './errors';
-export { IModelConstructor, Model } from './model';
+export { Hooks, IModelConstructor, Model, Property } from './model';
 export { ModelArray } from './model-array';
 export { utils };

--- a/packages/octonom/lib/main.ts
+++ b/packages/octonom/lib/main.ts
@@ -3,6 +3,6 @@ import * as utils from './utils';
 export { ArrayCollection } from './array-collection';
 export { Collection, ICollectionOptions } from './collection';
 export { ValidationError } from './errors';
-export { Hooks, IModelConstructor, Model, Property } from './model';
+export { IModelConstructor, Model, Property } from './model';
 export { ModelArray } from './model-array';
 export { utils };

--- a/packages/octonom/lib/model-array.spec.ts
+++ b/packages/octonom/lib/model-array.spec.ts
@@ -7,7 +7,7 @@ describe('ModelArray', () => {
   const catObj = {id: '42', name: 'Yllim'};
   const cat = new CatModel(catObj);
 
-  beforeEach(() => array = new ModelArray(CatModel));
+  beforeEach(() => array = new ModelArray<CatModel>(CatModel));
 
   describe('constructor', () => {
     it('should create an empty array', () => {
@@ -15,7 +15,7 @@ describe('ModelArray', () => {
     });
 
     it('should create an initialized array with raw objects', () => {
-      const initializedArray = new ModelArray(CatModel, [catObj]);
+      const initializedArray = new ModelArray<CatModel>(CatModel, [catObj]);
       expect(initializedArray).to.have.length(1);
       expect(initializedArray[0]).to.be.an.instanceOf(CatModel);
       expect(initializedArray[0].toObject()).to.eql(catObj);

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -42,6 +42,15 @@ describe('Hook decorator', () => {
     expect((Hooked.hooks as any).handlers.afterSet).to.eql([afterSet]);
   });
 
+  it('should create separate Hook instances for new classes', () => {
+    @Hook('beforeSet', beforeSet)
+    class DoubleHooked extends Hooked {}
+    expect((Hooked.hooks as any).handlers.beforeSet).to.eql([beforeSet]);
+    expect((Hooked.hooks as any).handlers.afterSet).to.eql([afterSet]);
+    expect((DoubleHooked.hooks as any).handlers.beforeSet).to.eql([beforeSet, beforeSet]);
+    expect((DoubleHooked.hooks as any).handlers.afterSet).to.eql([afterSet]);
+  });
+
   describe('set handlers', () => {
     it('should run handlers when constructed', () => {
       const hooked = new Hooked({foo: 'bar'});

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -93,7 +93,23 @@ describe('Hook decorator', () => {
 });
 
 describe('Property decorator', () => {
-  it('should register a schema property');
+  class TestModel extends Model {
+    @Property({type: 'string'})
+    public foo: string;
+  }
+
+  it('should register a schema property', () => {
+    expect(TestModel.schema).to.eql({foo: {type: 'string'}});
+  });
+
+  it('should create a separate for new classes', () => {
+    class Derived extends TestModel {
+      @Property({type: 'string'})
+      public bar: string;
+    }
+    expect(TestModel.schema).to.eql({foo: {type: 'string'}});
+    expect(Derived.schema).to.eql({foo: {type: 'string'}, bar: {type: 'string'}});
+  });
 });
 
 describe('Model', () => {

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -33,7 +33,8 @@ describe('Hook decorator', () => {
     @Property({type: 'string'})
     public foo: string;
 
-
+    @Property({type: 'string'})
+    public baz: string;
   }
 
   it('should register handlers', () => {
@@ -52,11 +53,11 @@ describe('Hook decorator', () => {
   it('should run handlers when calling set()', () => {
     const hooked = new Hooked({});
     resetSpies();
-    hooked.set({foo: 'bar'});
-    expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
+    hooked.set({foo: 'bar', baz: 'lol'});
+    expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
     expect(beforeObj).to.eql({});
-    expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
-    expect(afterObj).to.eql({foo: 'bar'});
+    expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
+    expect(afterObj).to.eql({foo: 'bar', baz: 'lol'});
   });
 });
 

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -134,13 +134,13 @@ describe('Model', () => {
       });
 
       it('should create a group with a model array with person instances', () => {
-        const members = new ModelArray(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
+        const members = new ModelArray<PersonModel>(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
         const group = new GroupWithArrayModel({members});
         expect(group.members).to.equal(members);
       });
 
       it('should throw if a model array is provided with the wrong model', () => {
-        const cats = new ModelArray(CatModel, [{name: 'Yllim'}]);
+        const cats = new ModelArray<CatModel>(CatModel, [{name: 'Yllim'}]);
         expect(() => new GroupWithArrayModel({members: cats})).to.throw('ModelArray model mismatch');
       });
     });
@@ -157,14 +157,14 @@ describe('Model', () => {
       });
 
       it('should set a model array with person instances', () => {
-        const members = new ModelArray(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
+        const members = new ModelArray<PersonModel>(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
         const group = new GroupWithArrayModel();
         group.set({members});
         expect(group.members).to.equal(members);
       });
 
       it('should throw if a model array is provided with the wrong model', () => {
-        const cats = new ModelArray(CatModel, [{name: 'Yllim'}]);
+        const cats = new ModelArray<CatModel>(CatModel, [{name: 'Yllim'}]);
         const group = new GroupWithArrayModel();
         expect(() => group.set({members: cats})).to.throw('ModelArray model mismatch');
       });
@@ -182,14 +182,14 @@ describe('Model', () => {
       });
 
       it('should set a model array with a person instance', () => {
-        const members = new ModelArray(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
+        const members = new ModelArray<PersonModel>(PersonModel, [{name: 'Alice'}, {name: 'Bob'}]);
         const group = new GroupWithArrayModel();
         group.members = members;
         expect(group.members).to.equal(members);
       });
 
       it('should throw if a model array is provided with the wrong model', () => {
-        const cats = new ModelArray(CatModel, [{name: 'Yllim'}]);
+        const cats = new ModelArray<CatModel>(CatModel, [{name: 'Yllim'}]);
         const group = new GroupWithArrayModel();
         expect(() => group.members = cats).to.throw('ModelArray model mismatch');
       });

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -42,22 +42,44 @@ describe('Hook decorator', () => {
     expect((Hooked.hooks as any).handlers.afterSet).to.eql([afterSet]);
   });
 
-  it('should run handlers when constructed', () => {
-    const hooked = new Hooked({foo: 'bar'});
-    expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
-    expect(beforeObj).to.eql({});
-    expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
-    expect(afterObj).to.eql({foo: 'bar'});
-  });
+  describe('set handlers', () => {
+    it('should run handlers when constructed', () => {
+      const hooked = new Hooked({foo: 'bar'});
+      expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
+      expect(beforeObj).to.eql({});
+      expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
+      expect(afterObj).to.eql({foo: 'bar'});
+    });
 
-  it('should run handlers when calling set()', () => {
-    const hooked = new Hooked({});
-    resetSpies();
-    hooked.set({foo: 'bar', baz: 'lol'});
-    expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
-    expect(beforeObj).to.eql({});
-    expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
-    expect(afterObj).to.eql({foo: 'bar', baz: 'lol'});
+    it('should run handlers when calling set()', () => {
+      const hooked = new Hooked({});
+      resetSpies();
+      hooked.set({foo: 'bar', baz: 'lol'});
+      expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
+      expect(beforeObj).to.eql({});
+      expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar', baz: 'lol'}});
+      expect(afterObj).to.eql({foo: 'bar', baz: 'lol'});
+    });
+
+    it('should run handlers when setting a value', () => {
+      const hooked = new Hooked({});
+      resetSpies();
+      hooked.foo = 'bar';
+      expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
+      expect(beforeObj).to.eql({});
+      expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: 'bar'}});
+      expect(afterObj).to.eql({foo: 'bar'});
+    });
+
+    it('should run handlers when deleting a value', () => {
+      const hooked = new Hooked({foo: 'bar'});
+      resetSpies();
+      delete hooked.foo;
+      expect(beforeSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: undefined}});
+      expect(beforeObj).to.eql({foo: 'bar'});
+      expect(afterSet).to.be.calledOnce.and.calledWith({instance: hooked, data: {foo: undefined}});
+      expect(afterObj).to.eql({});
+    });
   });
 });
 

--- a/packages/octonom/lib/model.spec.ts
+++ b/packages/octonom/lib/model.spec.ts
@@ -113,6 +113,20 @@ describe('Property decorator', () => {
 });
 
 describe('Model', () => {
+  it('should allow non-schema properties', () => {
+    class TestModel extends Model {
+      @Property({type: 'string'})
+      public foo: string;
+
+      public bar: string;
+    }
+    const instance = new TestModel({foo: 'test'});
+    instance.bar = 'baz';
+    expect(instance).to.eql({foo: 'test', bar: 'baz'});
+    delete instance.bar;
+    expect(instance).to.eql({foo: 'test'});
+  });
+
   describe('simple (CatModel)', () => {
     describe('constructor', () => {
       it('should create an empty instance with generated id via default function', () => {

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash';
 
 import { HookHandlersMap, Hooks } from './hooks';
 import { IPopulateMap, populateObject } from './populate';
-import { ISanitizeOptions, sanitize, setObjectSanitized } from './sanitize';
+import { ISanitizeOptions, setObjectSanitized } from './sanitize';
 import { SchemaMap, SchemaValue } from './schema';
 import { IToObjectOptions, toObject } from './to-object';
 import { validateObject } from './validate';

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -6,29 +6,58 @@ import { SchemaMap, SchemaValue } from './schema';
 import { IToObjectOptions, toObject } from './to-object';
 import { validateObject } from './validate';
 
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
 export interface IModelConstructor<T extends Model> {
   schema: SchemaMap;
+  hooks: ModelHooks<T>;
   new (data: Partial<T>): T;
 }
 
-interface IModel {
+export interface IModel {
   constructor: typeof Model;
 }
 
-export abstract class Model {
-  public static schema: SchemaMap;
+export function Property(schema: SchemaValue): PropertyDecorator {
+  return (target: IModel, key: string) => {
+    const constructor = target.constructor;
+    constructor.schema = cloneDeep(constructor.schema);
+    constructor.schema[key] = schema;
+  };
+}
+
+export type setHook<T> = (instance?: T, data?: Partial<T>, options?: ISanitizeOptions) => void;
+export interface IModelHookOptions<T> {
+  beforeSet: setHook<T>;
+  afterSet: setHook<T>;
+}
+
+export type ModelHooks<T> = {
+  [k in keyof IModelHookOptions<T>]: Array<IModelHookOptions<T>[k]>;
+};
+
+export function Hooks<T extends Model>(hooks: Partial<IModelHookOptions<T>>) {
+  return (constructor: IModelConstructor<T>) => {
+    constructor.hooks = cloneDeep(constructor.hooks);
+    Object.keys(hooks).forEach(name => constructor.hooks[name].push(hooks[name]));
+  };
+}
+
+// TODO: Model can be made an abstract class but the type Constructor<Model>
+//       doesn't work anymore (e.g., used in mixins)
+export class Model {
+  public static schema: SchemaMap = {};
+
+  public static hooks: ModelHooks<Model> = {
+    beforeSet: [],
+    afterSet: [],
+  };
 
   /**
    * Attach schema information to the property
    * @param schema Schema definition
    */
-  public static Property(schema: SchemaValue): PropertyDecorator {
-    return (target: IModel, key: string) => {
-      const constructor = target.constructor;
-      constructor.schema = cloneDeep(constructor.schema || {});
-      constructor.schema[key] = schema;
-    };
-  }
+  public static Property = Property;
 
   // TODO: ideally we'd also use Partial<this> as the type for data
   constructor(data?) {
@@ -40,12 +69,33 @@ export abstract class Model {
 
     // create proxy that intercepts set operations
     // for running sanitization if the key is in the schema
-    return new Proxy(this, {
+    // note: we use proxy for the hooks so they don't need to
+    //       worry about sanitizing values (they do need to worry
+    //       about recursive set calls though!)
+    const proxy = new Proxy(this, {
       set(target, key, value, receiver) {
-        target[key] = schema[key] ? sanitize(schema[key], value) : value;
+        if (schema[key]) {
+          constructor.hooks.beforeSet.forEach(hook => hook(receiver, {[key]: value}));
+          target[key] = sanitize(schema[key], value);
+          constructor.hooks.afterSet.forEach(hook => hook(receiver, {[key]: value}));
+        } else {
+          target[key] = value;
+        }
+        return true;
+      },
+      deleteProperty(target, key) {
+        if (schema[key]) {
+          constructor.hooks.beforeSet.forEach(hook => hook(proxy, {[key]: undefined}));
+          delete target[key];
+          constructor.hooks.afterSet.forEach(hook => hook(proxy, {[key]: undefined}));
+        } else {
+          delete target[key];
+        }
         return true;
       },
     });
+
+    return proxy;
   }
 
   public inspect() {
@@ -60,7 +110,11 @@ export abstract class Model {
   // TODO: sanitize is called twice when this is called via the proxy
   public set(data: Partial<this>, options: ISanitizeOptions = {}) {
     const constructor = this.constructor as typeof Model;
+    constructor.hooks.beforeSet.forEach(hook => hook(this, data as any, options));
+
     setObjectSanitized(constructor.schema, this, data, options);
+
+    constructor.hooks.afterSet.forEach(hook => hook(this, data as any, options));
   }
 
   public toObject(options?: IToObjectOptions): Partial<this> {

--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -27,7 +27,7 @@ export function Property(schema: SchemaValue): PropertyDecorator {
   };
 }
 
-export function Hook<TModel extends Model,  K extends keyof HookHandlersMap<TModel>>(
+export function Hook<TModel extends Model, K extends keyof HookHandlersMap<TModel>>(
   name: K, handler: HookHandlersMap<TModel>[K][0],
 ) {
   return (constructor: IModelConstructor<TModel>) => {

--- a/packages/octonom/lib/sanitize.ts
+++ b/packages/octonom/lib/sanitize.ts
@@ -134,7 +134,7 @@ export function setObjectSanitized(schemaMap: SchemaMap, target: object, data: o
   }
 
   forEach(schemaMap, (schemaValue, key) => {
-    if (options.replace) {
+    if (options.replace || key in data) {
       delete target[key];
     }
 

--- a/packages/octonom/package.json
+++ b/packages/octonom/package.json
@@ -25,8 +25,8 @@
   "bugs": "https://github.com/paperhive/octonom/issues",
   "dependencies": {
     "@types/lodash": "^4.14.66",
-    "@types/node": "^8.0.2",
-    "@types/uuid": "^3.0.0",
+    "@types/node": "^8.0.27",
+    "@types/uuid": "^3.4.2",
     "lodash": "^4.17.4",
     "uuid": "^3.1.0"
   }

--- a/packages/octonom/test/data/collections.ts
+++ b/packages/octonom/test/data/collections.ts
@@ -7,9 +7,9 @@ import { GroupWithReferencesModel } from './models/group-with-references';
 import { PersonModel } from './models/person';
 
 export const collections = {
-  cats: new ArrayCollection(CatModel),
-  discussions: new ArrayCollection(DiscussionModel),
-  groupsWithArray: new ArrayCollection(GroupWithArrayModel),
-  groupsWithReferences: new ArrayCollection(GroupWithReferencesModel),
-  people: new ArrayCollection(PersonModel),
+  cats: new ArrayCollection<CatModel>(CatModel),
+  discussions: new ArrayCollection<DiscussionModel>(DiscussionModel),
+  groupsWithArray: new ArrayCollection<GroupWithArrayModel>(GroupWithArrayModel),
+  groupsWithReferences: new ArrayCollection<GroupWithReferencesModel>(GroupWithReferencesModel),
+  people: new ArrayCollection<PersonModel>(PersonModel),
 };

--- a/packages/octonom/test/data/models/cat.ts
+++ b/packages/octonom/test/data/models/cat.ts
@@ -8,4 +8,8 @@ export class CatModel extends Model {
   public name: string;
 
   public nonSchemaProperty: string;
+
+  constructor(data?: Partial<CatModel>) {
+    super(data);
+  }
 }

--- a/packages/octonom/test/data/models/discussion.ts
+++ b/packages/octonom/test/data/models/discussion.ts
@@ -12,4 +12,8 @@ export class DiscussionModel extends Model {
 
   @Model.Property({type: 'string'})
   public title: string;
+
+  constructor(data?: Partial<DiscussionModel>) {
+    super(data);
+  }
 }

--- a/packages/octonom/test/data/models/group-with-array.ts
+++ b/packages/octonom/test/data/models/group-with-array.ts
@@ -8,4 +8,8 @@ export class GroupWithArrayModel extends Model {
 
   @Model.Property({type: 'array', definition: {type: 'model', model: PersonModel}})
   public members: ModelArray<PersonModel> | Array<Partial<PersonModel>>;
+
+  constructor(data?: Partial<GroupWithArrayModel>) {
+    super(data);
+  }
 }

--- a/packages/octonom/test/data/models/group-with-references.ts
+++ b/packages/octonom/test/data/models/group-with-references.ts
@@ -9,4 +9,8 @@ export class GroupWithReferencesModel extends Model {
 
   @Model.Property({type: 'array', definition: {type: 'reference', collection: () => collections.people}})
   public members: Array<string | PersonModel>;
+
+  constructor(data?: Partial<GroupWithReferencesModel>) {
+    super(data);
+  }
 }

--- a/packages/octonom/test/data/models/person-account.ts
+++ b/packages/octonom/test/data/models/person-account.ts
@@ -3,4 +3,8 @@ import { Model } from '../../../lib/main';
 export class PersonAccountModel extends Model {
   @Model.Property({type: 'string'})
   public username: string;
+
+  constructor(data?: Partial<PersonAccountModel>) {
+    super(data);
+  }
 }

--- a/packages/octonom/test/data/models/person.ts
+++ b/packages/octonom/test/data/models/person.ts
@@ -11,4 +11,8 @@ export class PersonModel extends Model {
 
   @Model.Property({type: 'model', model: PersonAccountModel})
   public account?: Partial<PersonAccountModel>;
+
+  constructor(data?: Partial<PersonModel>) {
+    super(data);
+  }
 }


### PR DESCRIPTION
This PR introduces:

* `Hook` decorator (fixes #39): `afterSet`/`beforeSet` hooks are run before/after a `set()` is called on a Model instance or a property is assigned/deleted. Usage:
    ```typescript
    Hook('afterSet', ({instance, data, options}) => instance.updatedAt = new Date())
    class Updated extends Model {
      @Property({type: 'Date'})
      public updatedAt: Date;
    }
    ```
* `Timestamp` mixin (fixes #34): uses the `afterSet` hook to set and update `createdAt` and `updatedAt` fields. Usage:
    ```typescript
    class Timestamped extends Timestamp(Model) {
      @Property({type: 'string'})
      public name: string;
    }
    ```
    or
    ```typescript
    class Timestamped extends Timestamp(Base) {}
    ```
    where `Base` is derived from `Model`.
* Tests for `Property` (fixes #40)

The PR also reworks the `Model` proxy: `set()` is now always called on the unproxied object to prevent infinite recursion and consistent hook behavior (e.g., only called once per `set()` call). 