### PR TITLE
docker-compose: use mongo:3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mongodb:
-    image: mongo:3
+    image: mongo:3.4
     command: mongod --smallfiles
     ports:
     - "27017:27017"


### PR DESCRIPTION
Mongo 3.6 was released but apparently it's not yet compatible with the node mongodb driver. Pinning to `mongo:3.4` for now.