### PR TITLE
model: fix typescript error

### DIFF
--- a/packages/octonom/lib/model.ts
+++ b/packages/octonom/lib/model.ts
@@ -31,7 +31,7 @@ export function Hook<TModel extends Model, K extends keyof HookHandlersMap<TMode
 
 const shadowInstanceProperty = Symbol('shadowInstanceProperty');
 export const getShadowInstance = Symbol('getShadowInstance');
-const setShadowInstance = Symbol('setShadowInstance');
+export const setShadowInstance = Symbol('setShadowInstance');
 
 // TODO: think about model instances
 function sanitize(value: any, sanitizeOptions: ISanitizeOptions) {


### PR DESCRIPTION
fixes "Public method '[setShadowInstance]' of exported class has or is using private name 'setShadowInstance'"

Fixes #74 #75 #76.